### PR TITLE
Removed accidentally added dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,5 +25,5 @@ setup(
     author_email='mail@sebastianraschka.com',
     url='https://github.com/rasbt/watermark',
     packages=find_packages(exclude=[]),
-    install_requires=['ipython', 'jupyter']
+    install_requires=['ipython']
 )

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     author_email='mail@sebastianraschka.com',
     url='https://github.com/rasbt/watermark',
     packages=find_packages(exclude=[]),
-    install_requires=['ipython']
+    install_requires=['ipython'],
     long_description="""
 An IPython magic extension for printing date and time stamps, version numbers,
 and hardware information.


### PR DESCRIPTION
Noticed when testing on pip that I had accidentally added the jupyter dependency when debugging. But, I don't think the package needs it.

Sorry for the noise!