### PR TITLE
Fix for virtualenv compatability

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ To get an overview of all available commands, type:
 
 [[top](#sections)]
 
+#### v. 1.3.2 (August 3, 2016)
+
+- Fixes an issue where the wrong package info was obtained when using the system level jupyter within a virtualenv environment.
+
 #### v. 1.3.1 (June 6, 2016)
 
 - Fixing an issue that caused problems importing watermark using Python 2.x

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ repo_root = os.path.dirname(os.path.abspath(__file__))
 
 setup(
     name='watermark',
-    version='1.3.1',
+    version='1.3.2',
     license='newBSD',
     description=('IPython magic function to print date/time stamps and'
                  'various system information.'),
@@ -15,7 +15,7 @@ setup(
     author_email='mail@sebastianraschka.com',
     url='https://github.com/rasbt/watermark',
     packages=find_packages(exclude=[]),
-    install_requires=['ipython'],
+    install_requires=['ipython', 'pip'],
     long_description="""
 An IPython magic extension for printing date and time stamps, version numbers,
 and hardware information.

--- a/watermark/__init__.py
+++ b/watermark/__init__.py
@@ -8,4 +8,4 @@ else:
 
 __all__ = ['watermark']
 
-__version__ = '1.3.1'
+__version__ = '1.3.2'

--- a/watermark/watermark.py
+++ b/watermark/watermark.py
@@ -45,9 +45,10 @@ import platform
 import subprocess
 from time import strftime
 from socket import gethostname
-from pkg_resources import get_distribution
 from multiprocessing import cpu_count
+from __init__ import __version__
 
+import pip
 import IPython
 from IPython.core.magic import Magics
 from IPython.core.magic import magics_class
@@ -148,8 +149,9 @@ class WaterMark(Magics):
         if self.out:
             self.out += '\n'
         packages = pkgs.split(',')
+        installed_dists = {i.key: i.version for i in pip.get_installed_distributions()}
         for p in packages:
-            self.out += '\n%s %s' % (p, get_distribution(p).version)
+            self.out += '\n%s %s' % (p, installed_dists[p])
 
     def _get_pyversions(self):
         if self.out:


### PR DESCRIPTION
Fix for #15 using `pip` to fetch package info rather than `pkg_resources`. 

I was also getting an exception using the -w flag due to `__version__` being unreferenced, so I added `import __init__` to make the version accessible within `watermark.py`. 