### PR TITLE
Add Git repo option

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ optional arguments:
 [[top](#sections)]
 
 
+#### v. 1.4.0dev0 (February 1, 2017)
+
+- Adds a new `-`/ `--gitrepo` parameter that returns the URL of Git remote name "origin". (via contribution by [Lucy Park](https://github.com/e9t))
+
 #### v. 1.3.4 (October 15, 2016)
 
 - Allow fetching scikit-learn's version number via `-p scikit-learn` in addition of `-p sklearn` (the former is deprecated and will not be supported in watermarl > 1.7)

--- a/watermark/__init__.py
+++ b/watermark/__init__.py
@@ -9,7 +9,7 @@
 import sys
 
 
-__version__ = '1.3.4'
+__version__ = '1.3.4-dev.e9t'
 
 if sys.version_info >= (3, 0):
     from watermark.watermark import *

--- a/watermark/__init__.py
+++ b/watermark/__init__.py
@@ -9,7 +9,7 @@
 import sys
 
 
-__version__ = '1.3.4-dev.e9t'
+__version__ = '1.4.0dev0'
 
 if sys.version_info >= (3, 0):
     from watermark.watermark import *

--- a/watermark/watermark.py
+++ b/watermark/watermark.py
@@ -7,7 +7,6 @@ License: BSD 3 clause
 """
 
 from . import __version__
-import sys
 import platform
 import subprocess
 from time import strftime
@@ -65,6 +64,8 @@ class WaterMark(Magics):
               help='prints system and machine info')
     @argument('-g', '--githash', action='store_true',
               help='prints current Git commit hash')
+    @argument('-r', '--gitrepo', action='store_true',
+              help='prints current Git remote address')
     @argument('-w', '--watermark', action='store_true',
               help='prints the current version of watermark')
     @line_magic
@@ -121,6 +122,8 @@ class WaterMark(Magics):
                 self.out += '\nhost name%s: %s' % (space, gethostname())
             if args.githash:
                 self._get_commit_hash(bool(args.machine))
+            if args.gitrepo:
+                self._get_git_remote_origin(bool(args.machine))
             if args.watermark:
                 if self.out:
                     self.out += '\n'
@@ -187,6 +190,16 @@ class WaterMark(Magics):
         if machine:
             space = '   '
         self.out += '\nGit hash%s: %s' % (space, git_head_hash.decode("utf-8"))
+
+    def _get_git_remote_origin(self, machine):
+        process = subprocess.Popen(['git', 'config', '--get', 'remote.origin.url'],
+                                   shell=False,
+                                   stdout=subprocess.PIPE)
+        git_remote_origin = process.communicate()[0].strip()
+        space = ''
+        if machine:
+            space = '   '
+        self.out += '\nGit repo%s: %s' % (space, git_remote_origin.decode("utf-8"))
 
 
 def load_ipython_extension(ipython):


### PR DESCRIPTION
I've realized that having the Git hash was very useful, but it would probably be more useful with the Git repo itself.

![screen shot 2017-02-01 at 2 53 27 pm](https://cloud.githubusercontent.com/assets/1205890/22496608/7b6a0718-e88e-11e6-9e24-d8bc68fb9276.png)