### PR TITLE
Add gitbranch option

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ optional arguments:
 -m,  --machine         prints system and machine info
 -g,  --githash         prints current Git commit hash
 -r,  --gitrepo         prints current Git remote address
+-b,  --gitbranch       prints the current Git branch (new in v1.6)
 -iv, --iversion        print name and version of all imported packages      
 -w,  --watermark       prints the current version of watermark
 ```

--- a/watermark/__init__.py
+++ b/watermark/__init__.py
@@ -9,7 +9,7 @@
 import sys
 
 
-__version__ = '1.5.0'
+__version__ = '1.6.0dev'
 
 if sys.version_info >= (3, 0):
     from watermark.watermark import *

--- a/watermark/watermark.py
+++ b/watermark/watermark.py
@@ -221,7 +221,7 @@ class WaterMark(Magics):
         git_branch = process.communicate()[0].strip()
         space = ''
         if machine:
-            space = '   '
+            space = ' '
         self.out += '\nGit branch%s: %s' % (space,
                                             git_branch.decode("utf-8"))
 

--- a/watermark/watermark.py
+++ b/watermark/watermark.py
@@ -67,6 +67,8 @@ class WaterMark(Magics):
               help='prints current Git commit hash')
     @argument('-r', '--gitrepo', action='store_true',
               help='prints current Git remote address')
+    @argument('-b', '--gitbranch', action='store_true',
+              help='prints current Git branch')
     @argument('-w', '--watermark', action='store_true',
               help='prints the current version of watermark')
     @argument('-iv', '--iversions', action='store_true',
@@ -127,6 +129,8 @@ class WaterMark(Magics):
                 self._get_commit_hash(bool(args.machine))
             if args.gitrepo:
                 self._get_git_remote_origin(bool(args.machine))
+            if args.gitbranch:
+                self._get_git_branch(bool(args.machine))
             if args.iversions:
                 self._print_all_import_versions(self.shell.user_ns)
             if args.watermark:
@@ -208,6 +212,18 @@ class WaterMark(Magics):
             space = '   '
         self.out += '\nGit repo%s: %s' % (space,
                                           git_remote_origin.decode("utf-8"))
+
+    def _get_git_branch(self, machine):
+        process = subprocess.Popen(['git', 'rev-parse', '--abbrev-ref',
+                                    'HEAD'],
+                                   shell=False,
+                                   stdout=subprocess.PIPE)
+        git_branch = process.communicate()[0].strip()
+        space = ''
+        if machine:
+            space = '   '
+        self.out += '\nGit branch%s: %s' % (space,
+                                            git_branch.decode("utf-8"))
 
     @staticmethod
     def _print_all_import_versions(vars):


### PR DESCRIPTION
Adds an option to display the current Git branch via the `-b` and `--gitbranch` flags as suggested in #36 .

 E.g.,

```python
%load_ext watermark
%watermark -d -b
```

```
2018-01-17 
Git branch: test-branch
```