### PR TITLE
v 1.8.0, allow support `from X import Y` via `-iv`

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,29 @@ optional arguments:
 
 [[top](#sections)]
 
+#### v. 1.8.0 (January 02, 2019)
+
+- The `-iv`/`--iversion` flag now also shows package versions that were imported as `from X import Y`
+and `import X.Y as Y`. For example,
+
+```python
+import scipy as sp
+from sklearn import metrics
+import numpy.linalg as linalg
+```
+
+```python
+%watermark --iversions
+```
+
+will return
+
+```python
+scipy     1.1.0
+sklearn   0.20.1
+numpy     1.15.4
+```
+
 #### v. 1.7.0 (October 13, 2018)
 
 (Via contribution by [James Myatt](https://github.com/jamesmyatt))

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build Status](https://travis-ci.org/rasbt/watermark.svg?branch=master)](https://travis-ci.org/rasbt/watermark)
 [![PyPI version](https://badge.fury.io/py/watermark.svg)](http://badge.fury.io/py/watermark)
 ![Python 2.7](https://img.shields.io/badge/python-2.7-blue.svg)
-![Python 3.5](https://img.shields.io/badge/python-3.5-blue.svg)
+![Python 3.7](https://img.shields.io/badge/python-3.7-blue.svg)
 ![License](https://img.shields.io/badge/license-BSD-blue.svg)
 
 watermark

--- a/README.md
+++ b/README.md
@@ -123,13 +123,13 @@ from sklearn import metrics
 import numpy.linalg as linalg
 ```
 
-```python
+```
 %watermark --iversions
 ```
 
 will return
 
-```python
+```
 scipy     1.1.0
 sklearn   0.20.1
 numpy     1.15.4

--- a/docs/watermark.ipynb
+++ b/docs/watermark.ipynb
@@ -179,17 +179,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2016-08-16T18:03:25-04:00\n",
+      "2019-01-02T19:50:57-06:00\n",
       "\n",
-      "CPython 3.5.1\n",
-      "IPython 5.0.0\n",
+      "CPython 3.6.5\n",
+      "IPython 6.5.0\n",
       "\n",
-      "compiler   : GCC 4.2.1 Compatible Apple LLVM 4.2 (clang-425.0.28)\n",
+      "compiler   : GCC 4.2.1 Compatible Apple LLVM 6.1.0 (clang-602.0.53)\n",
       "system     : Darwin\n",
-      "release    : 15.6.0\n",
+      "release    : 18.2.0\n",
       "machine    : x86_64\n",
       "processor  : i386\n",
-      "CPU cores  : 4\n",
+      "CPU cores  : 8\n",
       "interpreter: 64bit\n"
      ]
     }
@@ -207,6 +207,23 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2019-01-02 19:50:57\n"
+     ]
+    }
+   ],
+   "source": [
+    "%watermark  -t -d"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 5,
    "metadata": {},
    "outputs": [
@@ -214,12 +231,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2016-08-16 18:03:31\n"
+      "2019-01-02T19:50:57-06:00\n"
      ]
     }
    ],
    "source": [
-    "%watermark  -t -d"
+    "%watermark  --iso8601"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<br>"
    ]
   },
   {
@@ -231,12 +255,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2016-08-16T18:03:42-04:00\n"
+      "last updated: Wed Jan 02 2019 19:50:57 CST\n"
      ]
     }
    ],
    "source": [
-    "%watermark  --iso8601"
+    "%watermark -u -n -t -z"
    ]
   },
   {
@@ -255,12 +279,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "last updated: Tue Aug 16 2016 18:03:47 EDT\n"
+      "CPython 3.6.5\n",
+      "IPython 6.5.0\n"
      ]
     }
    ],
    "source": [
-    "%watermark -u -n -t -z"
+    "%watermark -v"
    ]
   },
   {
@@ -279,13 +304,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPython 3.5.1\n",
-      "IPython 5.0.0\n"
+      "compiler   : GCC 4.2.1 Compatible Apple LLVM 6.1.0 (clang-602.0.53)\n",
+      "system     : Darwin\n",
+      "release    : 18.2.0\n",
+      "machine    : x86_64\n",
+      "processor  : i386\n",
+      "CPU cores  : 8\n",
+      "interpreter: 64bit\n"
      ]
     }
    ],
    "source": [
-    "%watermark -v"
+    "%watermark -m"
    ]
   },
   {
@@ -304,18 +334,25 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "compiler   : GCC 4.2.1 Compatible Apple LLVM 4.2 (clang-425.0.28)\n",
+      "CPython 3.6.5\n",
+      "IPython 6.5.0\n",
+      "\n",
+      "numpy 1.15.4\n",
+      "scipy 1.1.0\n",
+      "\n",
+      "compiler   : GCC 4.2.1 Compatible Apple LLVM 6.1.0 (clang-602.0.53)\n",
       "system     : Darwin\n",
-      "release    : 15.6.0\n",
+      "release    : 18.2.0\n",
       "machine    : x86_64\n",
       "processor  : i386\n",
-      "CPU cores  : 4\n",
-      "interpreter: 64bit\n"
+      "CPU cores  : 8\n",
+      "interpreter: 64bit\n",
+      "Git hash   : 3f2c75a99214fa379d9091eeb5933c30c4ea9751\n"
      ]
     }
    ],
    "source": [
-    "%watermark -m"
+    "%watermark -v -m -p numpy,scipy -g"
    ]
   },
   {
@@ -334,54 +371,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPython 3.5.1\n",
-      "IPython 5.0.0\n",
+      "John Doe 2019-01-02 \n",
       "\n",
-      "numpy 1.11.1\n",
-      "scipy 0.17.1\n",
+      "CPython 3.6.5\n",
+      "IPython 6.5.0\n",
       "\n",
-      "compiler   : GCC 4.2.1 Compatible Apple LLVM 4.2 (clang-425.0.28)\n",
+      "compiler   : GCC 4.2.1 Compatible Apple LLVM 6.1.0 (clang-602.0.53)\n",
       "system     : Darwin\n",
-      "release    : 15.6.0\n",
+      "release    : 18.2.0\n",
       "machine    : x86_64\n",
       "processor  : i386\n",
-      "CPU cores  : 4\n",
-      "interpreter: 64bit\n",
-      "Git hash   : fbeb63abe159172529542e202a8c92ec3227099d\n"
-     ]
-    }
-   ],
-   "source": [
-    "%watermark -v -m -p numpy,scipy -g"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<br>"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "John Doe 2016-08-16 \n",
-      "\n",
-      "CPython 3.5.1\n",
-      "IPython 5.0.0\n",
-      "\n",
-      "compiler   : GCC 4.2.1 Compatible Apple LLVM 4.2 (clang-425.0.28)\n",
-      "system     : Darwin\n",
-      "release    : 15.6.0\n",
-      "machine    : x86_64\n",
-      "processor  : i386\n",
-      "CPU cores  : 4\n",
+      "CPU cores  : 8\n",
       "interpreter: 64bit\n"
      ]
     }
@@ -392,27 +392,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 11,
+   "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy as np\n",
-    "import scipy as sp"
+    "import scipy as sp\n",
+    "from sklearn import metrics\n",
+    "import numpy.linalg as linalg"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "numpy       1.12.1\n",
-      "scipy       0.19.1\n",
+      "scipy     1.1.0\n",
+      "sklearn   0.20.1\n",
+      "numpy     1.15.4\n",
       "\n"
      ]
     }
@@ -438,7 +438,20 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.6.5"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
   }
  },
  "nbformat": 4,

--- a/watermark/__init__.py
+++ b/watermark/__init__.py
@@ -9,7 +9,7 @@
 import sys
 
 
-__version__ = '1.7.0'
+__version__ = '1.8.0'
 
 if sys.version_info >= (3, 0):
     from watermark.watermark import *

--- a/watermark/watermark.py
+++ b/watermark/watermark.py
@@ -241,7 +241,7 @@ class WaterMark(Magics):
                     except AttributeError as e:
                         try:
                             imported = __import__(val.__name__.split('.')[0])
-                            to_print.add((imported.__name__, 
+                            to_print.add((imported.__name__,
                                           imported.__version__))
                         except AttributeError as e:
                             continue

--- a/watermark/watermark.py
+++ b/watermark/watermark.py
@@ -73,8 +73,6 @@ class WaterMark(Magics):
               help='prints the current version of watermark')
     @argument('-iv', '--iversions', action='store_true',
               help='prints the name/version of all imported modules')
-    @argument('--nvidia-gpus', action='store_true',
-              help='Lists all GPUs available using nvidia-smi')
     @line_magic
     def watermark(self, line):
         """

--- a/watermark/watermark.py
+++ b/watermark/watermark.py
@@ -73,6 +73,8 @@ class WaterMark(Magics):
               help='prints the current version of watermark')
     @argument('-iv', '--iversions', action='store_true',
               help='prints the name/version of all imported modules')
+    @argument('--nvidia-gpus', action='store_true',
+              help='Lists all GPUs available using nvidia-smi')
     @line_magic
     def watermark(self, line):
         """
@@ -230,21 +232,21 @@ class WaterMark(Magics):
 
     @staticmethod
     def _print_all_import_versions(vars):
+        to_print = set()
         for val in list(vars.values()):
             if isinstance(val, types.ModuleType):
-                try:
-                    print('{:<10}  {}'.format(val.__name__, val.__version__))
-                except AttributeError:
-                    continue
-
-    @staticmethod
-    def _print_all_import_versions(vars):
-        for val in list(vars.values()):
-            if isinstance(val, types.ModuleType):
-                try:
-                    print('{:<10}  {}'.format(val.__name__, val.__version__))
-                except AttributeError:
-                    continue
+                if val.__name__ != 'builtins':
+                    try:
+                        to_print.add((val.__name__, val.__version__))
+                    except AttributeError as e:
+                        try:
+                            imported = __import__(val.__name__.split('.')[0])
+                            to_print.add((imported.__name__, 
+                                          imported.__version__))
+                        except AttributeError as e:
+                            continue
+        for entry in to_print:
+            print('%-10s%s' % (entry[0], entry[1]))
 
 
 def load_ipython_extension(ipython):


### PR DESCRIPTION
Adds support for packages that were imported via the `from X import Y` scheme via `-iv`. 

For example,

```python
import scipy as sp
from sklearn import metrics
import numpy.linalg as linalg
```

```
%watermark --iversions
```

will return

```
scipy     1.1.0
sklearn   0.20.1
numpy     1.15.4
```

---

Fixes #44 