### PR TITLE
v 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,11 @@ optional arguments:
 
 [[top](#sections)]
 
+#### v. 2.0.0 (October 04, 2019)
+
+- Now uses `pkg_resources` as the default method for getting version numbers.
+- Fixes a whitespace bug when printing the timezone.
+
 #### v. 1.8.2 (July 28, 2019)
 
 - When no Python library was imported and the `--iversion` is used, print an empty string instead of raising an error.

--- a/docs/watermark.ipynb
+++ b/docs/watermark.ipynb
@@ -81,6 +81,30 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "The version of `watermark` itself can be retrieved as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "watermark 2.0.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "%watermark --watermark"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "<br>\n",
     "<br>"
    ]
@@ -101,7 +125,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -201,21 +225,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2019-07-28T22:28:28+02:00\n",
+      "2019-10-04T17:24:54-05:00\n",
       "\n",
       "CPython 3.7.1\n",
-      "IPython 7.6.1\n",
+      "IPython 7.8.0\n",
       "\n",
       "compiler   : Clang 4.0.1 (tags/RELEASE_401/final)\n",
       "system     : Darwin\n",
-      "release    : 18.6.0\n",
+      "release    : 18.7.0\n",
       "machine    : x86_64\n",
       "processor  : i386\n",
       "CPU cores  : 12\n",
@@ -236,23 +260,6 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2019-07-28 22:28:28\n"
-     ]
-    }
-   ],
-   "source": [
-    "%watermark  -t -d"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 5,
    "metadata": {},
    "outputs": [
@@ -260,19 +267,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2019-07-28T22:28:28+02:00\n"
+      "2019-10-04 17:24:54\n"
      ]
     }
    ],
    "source": [
-    "%watermark  --iso8601"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<br>"
+    "%watermark  -t -d"
    ]
   },
   {
@@ -284,12 +284,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "last updated: Sun Jul 28 2019 22:28:28 CEST\n"
+      "2019-10-04T17:24:54-05:00\n"
      ]
     }
    ],
    "source": [
-    "%watermark -u -n -t -z"
+    "%watermark  --iso8601"
    ]
   },
   {
@@ -308,13 +308,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPython 3.7.1\n",
-      "IPython 7.6.1\n"
+      "last updated: Fri Oct 04 2019 17:24:54 CDT\n"
      ]
     }
    ],
    "source": [
-    "%watermark -v"
+    "%watermark -u -n -t -z"
    ]
   },
   {
@@ -333,9 +332,34 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "CPython 3.7.1\n",
+      "IPython 7.8.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "%watermark -v"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<br>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "compiler   : Clang 4.0.1 (tags/RELEASE_401/final)\n",
       "system     : Darwin\n",
-      "release    : 18.6.0\n",
+      "release    : 18.7.0\n",
       "machine    : x86_64\n",
       "processor  : i386\n",
       "CPU cores  : 12\n",
@@ -356,7 +380,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -364,19 +388,19 @@
      "output_type": "stream",
      "text": [
       "CPython 3.7.1\n",
-      "IPython 7.6.1\n",
+      "IPython 7.8.0\n",
       "\n",
-      "numpy 1.16.4\n",
-      "scipy 1.3.0\n",
+      "numpy 1.17.2\n",
+      "scipy 1.3.1\n",
       "\n",
       "compiler   : Clang 4.0.1 (tags/RELEASE_401/final)\n",
       "system     : Darwin\n",
-      "release    : 18.6.0\n",
+      "release    : 18.7.0\n",
       "machine    : x86_64\n",
       "processor  : i386\n",
       "CPU cores  : 12\n",
       "interpreter: 64bit\n",
-      "Git hash   : bf45a20bf9fd857ec7f6cf5633ca7a10d3ddf2a1\n"
+      "Git hash   : 3ddf261316d321914ccb8511aae878c47f3f1eec\n"
      ]
     }
    ],
@@ -393,21 +417,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "John Doe 2019-07-28 \n",
+      "John Doe 2019-10-04 \n",
       "\n",
       "CPython 3.7.1\n",
-      "IPython 7.6.1\n",
+      "IPython 7.8.0\n",
       "\n",
       "compiler   : Clang 4.0.1 (tags/RELEASE_401/final)\n",
       "system     : Darwin\n",
-      "release    : 18.6.0\n",
+      "release    : 18.7.0\n",
       "machine    : x86_64\n",
       "processor  : i386\n",
       "CPU cores  : 12\n",
@@ -428,7 +452,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -439,16 +463,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "scipy   1.3.0\n",
+      "scipy   1.3.1\n",
+      "numpy   1.17.2\n",
       "sklearn 0.21.1\n",
-      "numpy   1.16.4\n",
       "\n"
      ]
     }

--- a/watermark/__init__.py
+++ b/watermark/__init__.py
@@ -9,7 +9,7 @@
 import sys
 
 
-__version__ = '1.8.2'
+__version__ = '2.0.0'
 
 if sys.version_info >= (3, 0):
     from watermark.watermark import *

--- a/watermark/watermark.py
+++ b/watermark/watermark.py
@@ -16,6 +16,7 @@ from socket import gethostname
 from multiprocessing import cpu_count
 import warnings
 import types
+import pkg_resources
 
 import IPython
 from IPython.core.magic import Magics
@@ -111,7 +112,7 @@ class WaterMark(Magics):
             if args.time:
                 self.out += '%s ' % strftime('%H:%M:%S')
             if args.timezone:
-                self.out += strftime('%Z')
+                self.out += '%s ' % strftime('%Z')
             if args.iso8601:
                 self.out += iso_dt
             if args.python:
@@ -150,7 +151,8 @@ class WaterMark(Magics):
                 warnings.simplefilter('always', DeprecationWarning)
                 warnings.warn("Importing scikit-learn as `scikit-learn` has"
                               " been depracated and will not be supported"
-                              " anymore in v1.7.0. Please use the package"
+                              " anymore in future versions of watermark."
+                              " Please use the package"
                               " name `sklearn` instead.",
                               DeprecationWarning)
             try:
@@ -159,15 +161,18 @@ class WaterMark(Magics):
                 ver = 'not installed'
             else:
                 try:
-                    ver = imported.__version__
+                    ver = pkg_resources.get_distribution(p).version
                 except AttributeError:
                     try:
-                        ver = imported.version
+                        ver = imported.__version__
                     except AttributeError:
                         try:
-                            ver = imported.version_info
+                            ver = imported.version
                         except AttributeError:
-                            ver = 'unknown'
+                            try:
+                                ver = imported.version_info
+                            except AttributeError:
+                                ver = 'unknown'
 
             self.out += '\n%s %s' % (p, ver)
 


### PR DESCRIPTION
- Now uses `pkg_resources` as the default method for getting version numbers.
- Fixes a whitespace bug when printing the timezone.

Fixes #53 #50 #41 