### PR TITLE
[ENH] additional version formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ optional arguments:
 
 [[top](#sections)]
 
+#### v. 2.0.2 (November 19, 2019)
+
+- Support `VERSION` attributes, in addition to `__version__` attributes.
+
 #### v. 2.0.1 (October 04, 2019)
 
 - Fix `'sklearn'` vs. `'scikit-learn'` import compatibility.

--- a/watermark/__init__.py
+++ b/watermark/__init__.py
@@ -9,7 +9,7 @@
 import sys
 
 
-__version__ = '2.0.1'
+__version__ = '2.0.2'
 
 if sys.version_info >= (3, 0):
     from watermark.watermark import *

--- a/watermark/watermark.py
+++ b/watermark/watermark.py
@@ -236,6 +236,7 @@ class WaterMark(Magics):
                         for v in ["VERSION", "__version__"]:
                             if hasattr(val, v):
                                 to_print.add((val.__name__, getattr(val, v)))
+                                break
                     except AttributeError as e:
                         try:
                             imported = __import__(val.__name__.split('.')[0])

--- a/watermark/watermark.py
+++ b/watermark/watermark.py
@@ -233,7 +233,9 @@ class WaterMark(Magics):
             if isinstance(val, types.ModuleType):
                 if val.__name__ != 'builtins':
                     try:
-                        to_print.add((val.__name__, val.__version__))
+                        for v in ["VERSION", "__version__"]:
+                            if hasattr(val, v):
+                                to_print.add((val.__name__, getattr(val, v)))
                     except AttributeError as e:
                         try:
                             imported = __import__(val.__name__.split('.')[0])


### PR DESCRIPTION
This PR allows for the recognition of (a certain type of) non-standard version label, `.VERSION`, when using the `watermark -iv` tag.
 * [example gist](https://gist.github.com/jGaboardi/dfc24b9e0d4e91b44bd260f2058936cb)