### PR TITLE
Adopt NEP 29

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
 .DS_Store
+
+# IDE directories
 .ipynb_checkpoints
+.vscode
+.idea
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 sudo: required
 dist: xenial
-language: python
-
-python: 3.7
+language: generic
 
 matrix:
     include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,19 @@
 sudo: required
 dist: xenial
 language: python
+
 matrix:
     include:
+        - python: 3.9-dev
+        - python: 3.8
         - python: 3.7
-        - python: 3.6
-        - python: 3.5
-        - python: 2.7
+
 install:
     - source ci/.travis_install.sh
+
 script:
     - bash ci/.travis_test.sh
+
 notifications:
     email:
       recipients:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ jobs:
             PYTHON_VERSION=3.7
         - env:
             PYTHON_VERSION=2.7
-      allow_failures:
+    allow_failures:
         - env:
             PYTHON_VERSION=2.7
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 dist: xenial
 language: generic
 
-matrix:
+jobs:
     include:
         - env:
             PYTHON_VERSION=3.9
@@ -10,6 +10,11 @@ matrix:
             PYTHON_VERSION=3.8
         - env:
             PYTHON_VERSION=3.7
+        - env:
+            PYTHON_VERSION=2.7
+      allow_failures:
+        - env:
+            PYTHON_VERSION=2.7
 
 install:
     - source ci/.travis_install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,16 @@ sudo: required
 dist: xenial
 language: python
 
+python: 3.7
+
 matrix:
     include:
-        - python: 3.9-dev
-        - python: 3.8
-        - python: 3.7
+        - env:
+            PYTHON_VERSION=3.9
+        - env:
+            PYTHON_VERSION=3.8
+        - env:
+            PYTHON_VERSION=3.7
 
 install:
     - source ci/.travis_install.sh

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![Build Status](https://travis-ci.org/rasbt/watermark.svg?branch=master)](https://travis-ci.org/rasbt/watermark)
 [![PyPI version](https://badge.fury.io/py/watermark.svg)](http://badge.fury.io/py/watermark)
-![Python 2.7](https://img.shields.io/badge/python-2.7-blue.svg)
 ![Python 3.7](https://img.shields.io/badge/python-3.7-blue.svg)
 ![License](https://img.shields.io/badge/license-BSD-blue.svg)
 
@@ -10,12 +9,12 @@ watermark
 An IPython magic extension for printing date and time stamps, version numbers, and hardware information.
 <br>
 
-
 #### Sections
 
 - [Examples](#examples)
 - [Installation and updating](#installation-and-updating)
 - [Usage](#usage)
+- [Development guidelines](#development-guidelines)
 - [Changelog](#changelog)
 
 <br>
@@ -102,15 +101,36 @@ optional arguments:
 -g,  --githash         prints current Git commit hash
 -r,  --gitrepo         prints current Git remote address
 -b,  --gitbranch       prints the current Git branch (new in v1.6)
--iv, --iversion        print name and version of all imported packages      
+-iv, --iversion        print name and version of all imported packages
 -w,  --watermark       prints the current version of watermark
 ```
+
+<br>
+
+## Development guidelines
+
+[[top](#sections)]
+
+In line with [NEP 29][nep-29], this project supports:
+
+- All minor versions of Python released 42 months prior to the project, and at minimum the two latest minor versions.
+
+[nep-29]: https://numpy.org/neps/nep-0029-deprecation_policy.html
 
 <br>
 
 ## Changelog
 
 [[top](#sections)]
+
+#### v. 2.1.0 (November 2020)
+
+_in progress_
+
+(Via contribution by [James Myatt](https://github.com/jamesmyatt))
+
+- Adopt [NEP 29][nep-29] and require Python version 3.7 or newer
+- Add Python 3.8 and 3.9 to Travis CI builds.
 
 #### v. 2.0.2 (November 19, 2019)
 
@@ -159,7 +179,7 @@ numpy     1.15.4
 #### v. 1.7.0 (October 13, 2018)
 
 (Via contribution by [James Myatt](https://github.com/jamesmyatt))
- 
+
 - Shows "not installed" for version of packages/modules that cannot be imported.
 - Shows "unknown" for version of packages/modules when version attribute cannot be found.
 - Add Python 3.6 and 3.7 to Travis CI builds.

--- a/ci/.travis_install.sh
+++ b/ci/.travis_install.sh
@@ -15,9 +15,8 @@ conda config --set always_yes yes --set changeps1 no
 conda update -q conda
 conda info -a
 
-conda create -n testenv python=$TRAVIS_PYTHON_VERSION ipython;
+conda create -n testenv python=$PYTHON_VERSION ipython -c conda-forge;
 source activate testenv;
 
 python --version;
-python -c 'import IPython';
-python setup.py install;
+python -m pip install .;

--- a/ci/.travis_install.sh
+++ b/ci/.travis_install.sh
@@ -2,21 +2,16 @@
 
 set -e
 
-if [ "${TRAVIS_PYTHON_VERSION}" == "2.7" ]; then
-    wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
-else
-    wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-fi
-
+wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
 bash miniconda.sh -b -p $HOME/miniconda
-export PATH="$HOME/miniconda/bin:$PATH"
+source "$HOME/miniconda/etc/profile.d/conda.sh"
 hash -r
 conda config --set always_yes yes --set changeps1 no
 conda update -q conda
 conda info -a
 
 conda create -n testenv python=$PYTHON_VERSION ipython -c conda-forge;
-source activate testenv;
+conda activate testenv;
 
 python --version;
 python -m pip install .;

--- a/ci/.travis_install.sh
+++ b/ci/.travis_install.sh
@@ -14,4 +14,9 @@ conda create -n testenv python=$PYTHON_VERSION ipython -c conda-forge;
 conda activate testenv;
 
 python --version;
-python -m pip install .;
+
+if [[ "$PYTHON_VERSION" == "2.7" ]]; then
+  python -m pip install . --ignore-requires-python;
+else
+  python -m pip install .;
+fi

--- a/ci/.travis_test.sh
+++ b/ci/.travis_test.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-source activate testenv;
-
 set -e
 
 python -c "import IPython; print('IPython %s' % IPython.__version__)";

--- a/ci/.travis_test.sh
+++ b/ci/.travis_test.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+source activate testenv;
+
 set -e
 
 python -c "import IPython; print('IPython %s' % IPython.__version__)";

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,10 +6,10 @@ classifiers =
     Intended Audience :: Developers
     Intended Audience :: Science/Research
     License :: OSI Approved :: BSD License
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.7
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
-    Programming Language :: Python :: 3.5
-    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3 only
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+
+[options]
+python_requires = >=3.7

--- a/setup.py
+++ b/setup.py
@@ -6,11 +6,13 @@
 # License: BSD 3 clause
 
 from setuptools import setup, find_packages
-import os
 import watermark
 
+# Single-source version using method 6 from
+# https://packaging.python.org/guides/single-sourcing-package-version/
 VERSION = watermark.__version__
 
+# Also see settings in setup.cfg
 setup(
     name='watermark',
     version=VERSION,

--- a/watermark/__init__.py
+++ b/watermark/__init__.py
@@ -9,6 +9,6 @@ from __future__ import absolute_import
 
 __version__ = '2.1.0'
 
-from watermark.watermark import *
+from .watermark import *
 
 __all__ = ['watermark']

--- a/watermark/__init__.py
+++ b/watermark/__init__.py
@@ -5,15 +5,8 @@
 #
 # License: BSD 3 clause
 
+__version__ = '2.1.0'
 
-import sys
-
-
-__version__ = '2.0.2'
-
-if sys.version_info >= (3, 0):
-    from watermark.watermark import *
-else:
-    from watermark import *
+from watermark.watermark import *
 
 __all__ = ['watermark']

--- a/watermark/__init__.py
+++ b/watermark/__init__.py
@@ -5,6 +5,8 @@
 #
 # License: BSD 3 clause
 
+from __future__ import absolute_import
+
 __version__ = '2.1.0'
 
 from watermark.watermark import *


### PR DESCRIPTION
- Removes support for Python 3.6 and earlier, in line with NEP 29
- Adds CI for Python 3.8 and 3.9

Closes #62, #61 
