### PR TITLE
importlib-related improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,10 +128,11 @@ In line with [NEP 29][nep-29], this project supports:
 
 _in progress_
 
-
 - Adopt [NEP 29][nep-29] and require Python version 3.7 or newer. ([#63](https://github.com/rasbt/watermark/pull/63), via contribution by [James Myatt](https://github.com/jamesmyatt))
 - Add Python 3.8 and 3.9 to Travis CI builds. ([#63](https://github.com/rasbt/watermark/pull/63), via contribution by [James Myatt](https://github.com/jamesmyatt))
+- Fix: Allow setup.py to run without install_requires already installed ([#67](https://github.com/rasbt/watermark/pull/67), via contribution by [James Myatt](https://github.com/jamesmyatt))
 - Major refactoring to improve code readability ([#64](https://github.com/rasbt/watermark/pull/64) and [65](https://github.com/rasbt/watermark/pull/65), via contribution by [Bahram Aghaei](https://github.com/GreatBahram))
+- Use importlib and importlib.metadata to determine package version numbers. ([#66](https://github.com/rasbt/watermark/pull/66), via contribution by [James Myatt](https://github.com/jamesmyatt))
 
 #### v. 2.0.2 (November 19, 2019)
 

--- a/setup.py
+++ b/setup.py
@@ -14,14 +14,17 @@ setup(
     name="watermark",
     license="newBSD",
     description=(
-        "IPython magic function to print date/time stamps and"
+        "IPython magic function to print date/time stamps and "
         "various system information."
     ),
     author="Sebastian Raschka",
     author_email="mail@sebastianraschka.com",
     url="https://github.com/rasbt/watermark",
     packages=find_packages(exclude=[]),
-    install_requires=["ipython", 'importlib-metadata < 3.0 ; python_version < "3.8"'],
+    install_requires=[
+        "ipython",
+        'importlib-metadata < 3.0 ; python_version < "3.8"',
+    ],
     long_description=dedent(
         """\
         An IPython magic extension for printing date and time stamps, version

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     author_email="mail@sebastianraschka.com",
     url="https://github.com/rasbt/watermark",
     packages=find_packages(exclude=[]),
-    install_requires=["ipython"],
+    install_requires=["ipython", 'importlib-metadata < 3.0 ; python_version < "3.8"'],
     long_description=dedent(
         """\
         An IPython magic extension for printing date and time stamps, version

--- a/watermark/__init__.py
+++ b/watermark/__init__.py
@@ -7,7 +7,7 @@
 
 from __future__ import absolute_import
 
-from .watermark import *
 from .version import __version__
+from .watermark import *
 
-__all__ = ['watermark']
+__all__ = ["watermark"]

--- a/watermark/version.py
+++ b/watermark/version.py
@@ -1,6 +1,10 @@
-import pkg_resources
+try:
+    import importlib.metadata as importlib_metadata
+except ImportError:
+    # Running on pre-3.8 Python; use importlib-metadata package
+    import importlib_metadata
 
 try:
-    __version__ = pkg_resources.get_distribution('watermark').version
+    __version__ = importlib_metadata.version('watermark')
 except Exception:
     __version__ = 'unknown'

--- a/watermark/version.py
+++ b/watermark/version.py
@@ -5,6 +5,6 @@ except ImportError:
     import importlib_metadata
 
 try:
-    __version__ = importlib_metadata.version('watermark')
+    __version__ = importlib_metadata.version("watermark")
 except Exception:
-    __version__ = 'unknown'
+    __version__ = "unknown"

--- a/watermark/watermark.py
+++ b/watermark/watermark.py
@@ -6,9 +6,10 @@ Author: Sebastian Raschka <sebastianraschka.com>
 License: BSD 3 clause
 """
 
-
 from __future__ import absolute_import
+
 import datetime
+import importlib
 import platform
 import subprocess
 import time
@@ -35,7 +36,6 @@ class WaterMark(Magics):
     """
     IPython magic function to print date/time stamps
     and various system information.
-
     """
 
     @magic_arguments()
@@ -162,7 +162,7 @@ class WaterMark(Magics):
         if pkg_name == "scikit-learn":
             pkg_name = "sklearn"
         try:
-            imported = __import__(pkg_name)
+            imported = importlib.import_module(pkg_name)
         except ImportError:
             version = "not installed"
         else:

--- a/watermark/watermark.py
+++ b/watermark/watermark.py
@@ -17,18 +17,18 @@ import types
 from multiprocessing import cpu_count
 from socket import gethostname
 
+try:
+    import importlib.metadata as importlib_metadata
+except ImportError:
+    # Running on pre-3.8 Python; use importlib-metadata package
+    import importlib_metadata
+
 import IPython
-import pkg_resources
 from IPython.core.magic import Magics, line_magic, magics_class
 from IPython.core.magic_arguments import argument, \
      magic_arguments, parse_argstring
-from pkg_resources import DistributionNotFound
 
 from .version import __version__
-
-
-class PackageNotFoundError(Exception):
-    pass
 
 
 @magics_class
@@ -167,8 +167,8 @@ class WaterMark(Magics):
             version = "not installed"
         else:
             try:
-                version = pkg_resources.get_distribution(pkg_name).version
-            except DistributionNotFound:
+                version = importlib_metadata.version(pkg_name)
+            except importlib_metadata.PackageNotFoundError:
                 try:
                     version = imported.__version__
                 except AttributeError:

--- a/watermark/watermark.py
+++ b/watermark/watermark.py
@@ -25,8 +25,8 @@ except ImportError:
 
 import IPython
 from IPython.core.magic import Magics, line_magic, magics_class
-from IPython.core.magic_arguments import argument, \
-     magic_arguments, parse_argstring
+from IPython.core.magic_arguments import (argument, magic_arguments,
+                                          parse_argstring)
 
 from .version import __version__
 


### PR DESCRIPTION
* Use `importlib.import_module` rather than `__import__`: https://docs.python.org/3/library/importlib.html#importlib.__import__
* Use `importlib.metadata` rather than `pkg_resources`: see option 5 in: https://packaging.python.org/guides/single-sourcing-package-version/

This is inline with best-practice from the Python docs.

Closes #56 