### PR TITLE
Allow setup.py to run without install_requires

### DIFF
--- a/ci/.travis_install.sh
+++ b/ci/.travis_install.sh
@@ -10,7 +10,7 @@ conda config --set always_yes yes --set changeps1 no
 conda update -q conda
 conda info -a
 
-conda create -n testenv python=$PYTHON_VERSION ipython -c conda-forge;
+conda create -n testenv python=$PYTHON_VERSION -c conda-forge;
 conda activate testenv;
 
 python --version;

--- a/ci/.travis_install.sh
+++ b/ci/.travis_install.sh
@@ -16,6 +16,7 @@ conda activate testenv;
 python --version;
 
 if [[ "$PYTHON_VERSION" == "2.7" ]]; then
+  python -m pip install ipython;
   python -m pip install . --ignore-requires-python;
 else
   python -m pip install .;

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,5 @@
 [metadata]
+version = 2.1.0
 license_file = LICENSE
 classifiers =
     Development Status :: 5 - Production/Stable

--- a/setup.py
+++ b/setup.py
@@ -9,14 +9,9 @@ from textwrap import dedent
 
 from setuptools import find_packages, setup
 
-from watermark import __version__ as VERSION
-# Single-source version using method 6 from
-# https://packaging.python.org/guides/single-sourcing-package-version/
-
 # Also see settings in setup.cfg
 setup(
     name="watermark",
-    version=VERSION,
     license="newBSD",
     description=(
         "IPython magic function to print date/time stamps and"

--- a/watermark/__init__.py
+++ b/watermark/__init__.py
@@ -7,8 +7,7 @@
 
 from __future__ import absolute_import
 
-__version__ = '2.1.0'
-
 from .watermark import *
+from .version import __version__
 
 __all__ = ['watermark']

--- a/watermark/version.py
+++ b/watermark/version.py
@@ -1,0 +1,6 @@
+import pkg_resources
+
+try:
+    __version__ = pkg_resources.get_distribution('watermark').version
+except Exception:
+    __version__ = 'unknown'

--- a/watermark/watermark.py
+++ b/watermark/watermark.py
@@ -6,7 +6,8 @@ Author: Sebastian Raschka <sebastianraschka.com>
 License: BSD 3 clause
 """
 
-from . import __version__
+from __future__ import absolute_import
+
 import platform
 import subprocess
 from time import strftime
@@ -25,6 +26,8 @@ from IPython.core.magic import line_magic
 from IPython.core.magic_arguments import argument
 from IPython.core.magic_arguments import magic_arguments
 from IPython.core.magic_arguments import parse_argstring
+
+from .version import __version__
 
 
 class PackageNotFoundError(Exception):


### PR DESCRIPTION
Uses the same technique as setuptools.

e.g.
https://github.com/pypa/setuptools/blob/master/setuptools/__init__.py
https://github.com/pypa/setuptools/blob/master/setuptools/version.py

See option 5 in https://packaging.python.org/guides/single-sourcing-package-version/

Closes #67 , Includes #68 