### PR TITLE
Add option to display active conda environment

### DIFF
--- a/watermark/magic.py
+++ b/watermark/magic.py
@@ -48,6 +48,8 @@ class WaterMark(Magics):
               help='prints Python and IPython version')
     @argument('-p', '--packages', type=str,
               help='prints versions of specified Python modules and packages')
+    @argument('-e', '--conda', action='store_true',
+              help='prints name of current conda environment')
     @argument('-h', '--hostname', action='store_true',
               help='prints the host name')
     @argument('-m', '--machine', action='store_true',

--- a/watermark/watermark.py
+++ b/watermark/watermark.py
@@ -11,6 +11,7 @@ from __future__ import absolute_import
 
 import datetime
 import importlib
+import os
 import platform
 import subprocess
 import time
@@ -32,7 +33,7 @@ from .version import __version__
 def watermark(author=None, current_date=False, datename=False,
               current_time=False, iso8601=False, timezone=False,
               updated=False, custom_time=None, python=False,
-              packages=None, hostname=False, machine=False,
+              packages=None, conda=False, hostname=False, machine=False,
               githash=False, gitrepo=False, gitbranch=False,
               watermark=False, iversions=False, watermark_self=None):
 
@@ -71,6 +72,9 @@ def watermark(author=None, current_date=False, datename=False,
 
     packages :
         prints versions of specified Python modules and packages
+
+    conda :
+        prints name of current conda environment
 
     hostname :
         prints the host name
@@ -137,6 +141,8 @@ def watermark(author=None, current_date=False, datename=False,
             output.append(_get_pyversions())
         if args['packages']:
             output.append(_get_packages(args['packages']))
+        if args['conda']:
+            output.append(_get_conda_env())
         if args['machine']:
             output.append(_get_sysinfo())
         if args['hostname']:
@@ -269,3 +275,8 @@ def _get_all_import_versions(vars):
         if pkg_version not in ("not installed", "unknown"):
             to_print[pkg_name] = pkg_version
     return to_print
+
+
+def _get_conda_env():
+    name = os.getenv('CONDA_DEFAULT_ENV', 'n/a')
+    return {"conda environment": name}


### PR DESCRIPTION
As I often need to check which of the many conda environments I used to run a notebook, I added a new option `-e`/`--conda` to display the name of the active environment.
This implements parts of #6, feel free to extend this.