### PR TITLE
Update importlib-metadata dependency to match Python 3.8 or later

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     packages=find_packages(exclude=[]),
     install_requires=[
         "ipython",
-        'importlib-metadata < 3.0 ; python_version < "3.8"',
+        'importlib-metadata >= 1.4 ; python_version < "3.8"',
     ],
     long_description=dedent(
         """\


### PR DESCRIPTION
Upper limit on importlib-metadata causes trouble installing on Python 3.7.
Instead pin to minimum version with Python 3.8 functionality according to https://github.com/python/importlib_metadata#compatibility