### PR TITLE
GPU Info

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,9 @@ In line with [NEP 29][nep-29], this project supports:
 
 [[top](#sections)]
 
+#### v. 2.4.0 (May 23, 2023)
+
+- Adds a new `--gpu` flag to print out GPU information (currently limited to NVIDIA devices) ([#90](https://github.com/rasbt/watermark/pull/63), via contribution by [907Resident](https://github.com/907Resident))
 
 
 #### v. 2.3.1 (May 27, 2022)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,7 @@ install:
 
 test_script:
   - set PYTHONPATH=%PYTHONPATH%;%CD%
+  - pip install -e .
   - pytest -sv
 
 notifications:

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -3,3 +3,4 @@ numpy
 scipy
 scikit-learn
 jupyter
+nvidia-ml-py3

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -3,5 +3,3 @@ numpy
 scipy
 scikit-learn
 jupyter
-
--e .

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -3,4 +3,4 @@ numpy
 scipy
 scikit-learn
 jupyter
-nvidia-ml-py3
+py3nvml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 ipython
 importlib-metadata >= 1.4
 importlib-metadata >= 1.4 ; python_version < 3.8
-py3nvml
+py3nvml >= 0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+ipython
+importlib-metadata >= 1.4
+importlib-metadata >= 1.4 ; python_version < 3.8
+pynvml >= 11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-ipython
+ipython >= 6.0
 importlib-metadata >= 1.4
-importlib-metadata >= 1.4 ; python_version < 3.8
 py3nvml >= 0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 ipython
 importlib-metadata >= 1.4
 importlib-metadata >= 1.4 ; python_version < 3.8
-pynvml >= 11.0
+py3nvml

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-version = 2.3.1
+version = 2.4.0
 license_file = LICENSE
 classifiers =
     Development Status :: 5 - Production/Stable

--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,19 @@
 #
 # License: BSD 3 clause
 
+from os.path import dirname, join, realpath
 from textwrap import dedent
 
 from setuptools import find_packages, setup
+
+
+PROJECT_ROOT = dirname(realpath(__file__))
+REQUIREMENTS_FILE = join(PROJECT_ROOT, "requirements.txt")
+
+with open(REQUIREMENTS_FILE) as f:
+    install_reqs = f.read().splitlines()
+
+install_reqs.append("setuptools")
 
 # Also see settings in setup.cfg
 setup(
@@ -24,6 +34,7 @@ setup(
     install_requires=[
         "ipython",
         'importlib-metadata >= 1.4 ; python_version < "3.8"',
+        "pynvml >= 11.0"
     ],
     long_description=dedent(
         """\

--- a/setup.py
+++ b/setup.py
@@ -31,11 +31,7 @@ setup(
     author_email="mail@sebastianraschka.com",
     url="https://github.com/rasbt/watermark",
     packages=find_packages(exclude=[]),
-    install_requires=[
-        "ipython",
-        'importlib-metadata >= 1.4 ; python_version < "3.8"',
-        "pynvml >= 11.0"
-    ],
+    install_requires=install_reqs,
     long_description=dedent(
         """\
         An IPython magic extension for printing date and time stamps, version

--- a/watermark/magic.py
+++ b/watermark/magic.py
@@ -70,6 +70,9 @@ class WaterMark(Magics):
               help='prints the current version of watermark')
     @argument('-iv', '--iversions', action='store_true',
               help='prints the name/version of all imported modules')
+    @argument('--gpu', action='store_true',
+              help='prints GPU information (currently limited to NVIDIA GPUs),'
+                   ' if available')
     @line_magic
     def watermark(self, line):
         """

--- a/watermark/tests/test_watermark.py
+++ b/watermark/tests/test_watermark.py
@@ -1,5 +1,10 @@
 # -*- coding: utf-8 -*-
 
+import sys
+import os
+
+sys.path.append(os.path.join("../watermark"))
+
 import watermark
 
 

--- a/watermark/tests/test_watermark_gpu.py
+++ b/watermark/tests/test_watermark_gpu.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+import sys
+import os
+
+sys.path.append(os.path.join("../watermark"))
+
+import watermark
+
+def test_gpu_info():
+    a = watermark.watermark(gpu=True)
+    txt = a.split('\n')
+    clean_txt = []
+    for t in txt:
+        t = t.strip()
+        if t:
+            t = t.split(':')[0]
+            clean_txt.append(t.strip())
+    clean_txt = set(clean_txt)
+
+    expected = [
+        'GPU Info',
+    ]
+
+    for i in expected:
+        assert i in clean_txt, print(f'{i} not in {clean_txt}')

--- a/watermark/watermark.py
+++ b/watermark/watermark.py
@@ -149,7 +149,6 @@ def watermark(
         output.append({"Last updated": iso_dt})
         output.append(_get_pyversions())
         output.append(_get_sysinfo())
-        output.append(_get_gpu_info())
     else:
         if args['author']:
             output.append({"Author": args['author'].strip("'\"")})

--- a/watermark/watermark.py
+++ b/watermark/watermark.py
@@ -332,9 +332,10 @@ def _get_conda_env():
     name = os.getenv('CONDA_DEFAULT_ENV', 'n/a')
     return {"conda environment": name}
 
+
 def _get_gpu_info():
     try:
-        gpu_info = []
+        gpu_info = [""]
         py3nvml.nvmlInit()
         num_gpus = py3nvml.nvmlDeviceGetCount()
         for i in range(num_gpus):
@@ -342,8 +343,11 @@ def _get_gpu_info():
             gpu_name = py3nvml.nvmlDeviceGetName(handle)
             gpu_info.append(f"GPU {i}: {gpu_name}")
         py3nvml.nvmlShutdown()
-        return {"GPU Info": "\n".join(gpu_info)}
+        return {"GPU Info": "\n  ".join(gpu_info)}
+
     except py3nvml.NVMLError_LibraryNotFound:
-        return{"GPU Info": "NVIDIA drivers do not appear to be installed on this machine."}
+        return {"GPU Info": "NVIDIA drivers do not appear "
+                "to be installed on this machine."}
     except:
-        return{"GPU Info": "GPU information is not available for this machine."}
+        return {"GPU Info": "GPU information is not "
+                "available for this machine."}

--- a/watermark/watermark.py
+++ b/watermark/watermark.py
@@ -18,6 +18,8 @@ import time
 import types
 from multiprocessing import cpu_count
 from socket import gethostname
+import platform
+import pynvml
 
 try:
     import importlib.metadata as importlib_metadata
@@ -30,14 +32,32 @@ import IPython
 from .version import __version__
 
 
-def watermark(author=None, email=None, github_username=None,
-              website=None, current_date=False, datename=False,
-              current_time=False, iso8601=False, timezone=False,
-              updated=False, custom_time=None, python=False,
-              packages=None, conda=False, hostname=False, machine=False,
-              githash=False, gitrepo=False, gitbranch=False,
-              watermark=False, iversions=False, watermark_self=None,
-              globals_=None):
+def watermark(
+        author=None, 
+        email=None, 
+        github_username=None,
+        website=None, 
+        current_date=False, 
+        datename=False,
+        current_time=False, 
+        iso8601=False, 
+        timezone=False,
+        updated=False, 
+        custom_time=None, 
+        python=False,
+        packages=None, 
+        conda=False, 
+        hostname=False, 
+        machine=False,
+        githash=False, 
+        gitrepo=False, 
+        gitbranch=False,
+        watermark=False, 
+        iversions=False, 
+        gpu=False,
+        watermark_self=None,
+        globals_=None
+):
 
     '''Function to print date/time stamps and various system information.
 
@@ -107,6 +127,9 @@ def watermark(author=None, email=None, github_username=None,
 
     iversions :
         prints the name/version of all imported modules
+    
+    gpu :
+        prints GPU information, if available
 
     watermark_self :
         instance of the watermark magics class, which is required
@@ -126,6 +149,7 @@ def watermark(author=None, email=None, github_username=None,
         output.append({"Last updated": iso_dt})
         output.append(_get_pyversions())
         output.append(_get_sysinfo())
+        output.append(_get_gpu_info())
     else:
         if args['author']:
             output.append({"Author": args['author'].strip("'\"")})
@@ -182,6 +206,8 @@ def watermark(author=None, email=None, github_username=None,
                     "to show imported package versions."
                 )
             output.append(_get_all_import_versions(ns))
+        if args['gpu']:
+            output.append(_get_gpu_info())
         if args['watermark']:
             output.append({"Watermark": __version__})
 
@@ -306,3 +332,19 @@ def _get_all_import_versions(vars):
 def _get_conda_env():
     name = os.getenv('CONDA_DEFAULT_ENV', 'n/a')
     return {"conda environment": name}
+
+def _get_gpu_info():
+    try:
+        gpu_info = []
+        pynvml.nvmlInit()
+        num_gpus = pynvml.nvmlDeviceGetCount()
+        for i in range(num_gpus):
+            handle = pynvml.nvmlDeviceGetHandleByIndex(i)
+            gpu_name = pynvml.nvmlDeviceGetName(handle).decode()
+            gpu_info.append(f"GPU {i}: {gpu_name}")
+        pynvml.nvmlShutdown()
+        return {"GPU Info": "\n".join(gpu_info)}
+    except pynvml.NVMLError_LibraryNotFound:
+        return{"GPU Info": "NVIDIA drivers do not appear to be installed on this machine."}
+    except:
+        return{"GPU Info": "GPU information is not available for this machine."}

--- a/watermark/watermark.py
+++ b/watermark/watermark.py
@@ -129,7 +129,7 @@ def watermark(
         prints the name/version of all imported modules
     
     gpu :
-        prints GPU information, if available
+        prints GPU information (currently limited to NVIDIA GPUs), if available
 
     watermark_self :
         instance of the watermark magics class, which is required

--- a/watermark/watermark.py
+++ b/watermark/watermark.py
@@ -19,7 +19,7 @@ import types
 from multiprocessing import cpu_count
 from socket import gethostname
 import platform
-import pynvml
+from py3nvml import py3nvml
 
 try:
     import importlib.metadata as importlib_metadata
@@ -335,15 +335,15 @@ def _get_conda_env():
 def _get_gpu_info():
     try:
         gpu_info = []
-        pynvml.nvmlInit()
-        num_gpus = pynvml.nvmlDeviceGetCount()
+        py3nvml.nvmlInit()
+        num_gpus = py3nvml.nvmlDeviceGetCount()
         for i in range(num_gpus):
-            handle = pynvml.nvmlDeviceGetHandleByIndex(i)
-            gpu_name = pynvml.nvmlDeviceGetName(handle).decode()
+            handle = py3nvml.nvmlDeviceGetHandleByIndex(i)
+            gpu_name = py3nvml.nvmlDeviceGetName(handle).decode()
             gpu_info.append(f"GPU {i}: {gpu_name}")
-        pynvml.nvmlShutdown()
+        py3nvml.nvmlShutdown()
         return {"GPU Info": "\n".join(gpu_info)}
-    except pynvml.NVMLError_LibraryNotFound:
+    except py3nvml.NVMLError_LibraryNotFound:
         return{"GPU Info": "NVIDIA drivers do not appear to be installed on this machine."}
     except:
         return{"GPU Info": "GPU information is not available for this machine."}

--- a/watermark/watermark.py
+++ b/watermark/watermark.py
@@ -339,7 +339,7 @@ def _get_gpu_info():
         num_gpus = py3nvml.nvmlDeviceGetCount()
         for i in range(num_gpus):
             handle = py3nvml.nvmlDeviceGetHandleByIndex(i)
-            gpu_name = py3nvml.nvmlDeviceGetName(handle).decode()
+            gpu_name = py3nvml.nvmlDeviceGetName(handle)
             gpu_info.append(f"GPU {i}: {gpu_name}")
         py3nvml.nvmlShutdown()
         return {"GPU Info": "\n".join(gpu_info)}


### PR DESCRIPTION
# TL;DR

Overall, I wanted an argument in `watermark` to allow the user to view GPU information. 

# Details

- I stumbled upon this issue #31 while trying to view my GPU capabilities 
- Since the issue has been open since 2017, I have taken a stab by submitting a PR to the argument `gpu` to `watermark`
- Note: This will only work with GPUs, where NVIDIA drivers are installed already. In the issue, @dartdog mentions, and I agree with, most people are not using AMD GPUs for data science. Therefore, I think that only accounting for NVIDIA drivers should be fine
- Lastly, I added a new file in `tests/` called `test_gpu_info.py`, which should allow the maintainers of this repo to quickly run a `pytest` to ensure that the `gpu` argument works as the maintainers see fit