### PR TITLE
Make py3nvml optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,15 +176,23 @@ In line with [NEP 29][nep-29], this project supports:
 
 [[top](#sections)]
 
+#### v. 2.4.3 (May 23, 2023)
+
+- Make `py3nvml` installation for GPU info optional. ([#92](https://github.com/rasbt/watermark/pull/92), via contribution by [Ben Greiner](https://github.com/bnavigator))
+
+#### v. 2.4.1 and v 2.4.2 (May 23, 2023)
+
+- PyPI and Conda-Forge packaging fixes.
+
 #### v. 2.4.0 (May 23, 2023)
 
-- Adds a new `--gpu` flag to print out GPU information (currently limited to NVIDIA devices) ([#90](https://github.com/rasbt/watermark/pull/63), via contribution by [907Resident](https://github.com/907Resident))
+- Adds a new `--gpu` flag to print out GPU information (currently limited to NVIDIA devices) ([#90](https://github.com/rasbt/watermark/pull/90), via contribution by [907Resident](https://github.com/907Resident))
 
 
 #### v. 2.3.1 (May 27, 2022)
 
 - Upper limit on importlib-metadata caused trouble installing on Python 3.7.
-  Instead pin to minimum version with Python 3.8 functionality according to https://github.com/python/importlib_metadata#compatibility  ([#86](https://github.com/rasbt/watermark/pull/63), via contribution by [James Myatt](https://github.com/jamesmyatt))
+  Instead pin to minimum version with Python 3.8 functionality according to https://github.com/python/importlib_metadata#compatibility  ([#86](https://github.com/rasbt/watermark/pull/86), via contribution by [James Myatt](https://github.com/jamesmyatt))
 
 #### v. 2.3.0 (January 3, 2022)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 ipython >= 6.0
 importlib-metadata >= 1.4
-py3nvml >= 0.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-version = 2.4.1
+version = 2.4.3
 license_file = LICENSE
 classifiers =
     Development Status :: 5 - Production/Stable

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
     url="https://github.com/rasbt/watermark",
     packages=find_packages(exclude=[]),
     install_requires=install_reqs,
+    extras_require={'gpu': ['py3nvml>=0.2']},
     long_description=dedent(
         """\
         An IPython magic extension for printing date and time stamps, version

--- a/watermark/watermark.py
+++ b/watermark/watermark.py
@@ -338,6 +338,10 @@ def _get_conda_env():
 
 
 def _get_gpu_info():
+    if py3nvml is None:
+        return {"GPU Info": "Install the gpu extra "
+                "(pip install 'watermark[gpu]') "
+                "to display GPU information for NVIDIA chipsets"}
     try:
         gpu_info = [""]
         py3nvml.nvmlInit()

--- a/watermark/watermark.py
+++ b/watermark/watermark.py
@@ -19,7 +19,11 @@ import types
 from multiprocessing import cpu_count
 from socket import gethostname
 import platform
-from py3nvml import py3nvml
+
+try:
+    from py3nvml import py3nvml
+except ImportError:
+    py3nvml = None
 
 try:
     import importlib.metadata as importlib_metadata


### PR DESCRIPTION
Not everyone has or wants to install bindings for a proprietary NVIDIA library. Let's keep it optional.