### PR TITLE
fixed -d and -t flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,10 @@ In line with [NEP 29][nep-29], this project supports:
 
 [[top](#sections)]
 
+#### v. 2.5.1.dev1 (TBD)
+
+- Extra args to allow printing `-d` (current date) and `-t` (current time) information without needing to use the `-u` (updated) flag.  ([#99](https://github.com/rasbt/watermark/pull/99), via contribution by [Daniel Kleine](https://github.com/d-kleine))
+
 #### v. 2.5.0 (Sep 20, 2024)
 
 - Can now capture imports retrospectively via `-iv` more reliably.  ([#94](https://github.com/rasbt/watermark/pull/94), via contribution by [Martin Perier](https://github.com/martinp7))

--- a/watermark/watermark.py
+++ b/watermark/watermark.py
@@ -186,8 +186,9 @@ def watermark(
             output.append({"Last updated": value})
         elif args['current_date'] or args['current_time']:
             if args['current_date'] and args['current_time']:
-                output.append({"Date": time.strftime("%Y-%m-%d")})
-                output.append({"Time": time.strftime("%H:%M:%S")})
+                date_str = time.strftime("%Y-%m-%d")
+                time_str = time.strftime("%H:%M:%S")
+                output.append({"Date/Time": f"{date_str} {time_str}"})
             elif args['current_date']:
                 output.append({"Date": time.strftime("%Y-%m-%d")})
             elif args['current_time']:

--- a/watermark/watermark.py
+++ b/watermark/watermark.py
@@ -183,6 +183,13 @@ def watermark(
                     values.append(time_str)
                 value = " ".join(values)
             output.append({"Last updated": value})
+        if args['current_date'] and args['current_time']:
+            output.append({"Date": time.strftime("%Y-%m-%d")})
+            output.append({"Time": time.strftime("%H:%M:%S")})
+        elif args['current_date']:
+            output.append({"Date": time.strftime("%Y-%m-%d")})
+        elif args['current_time']:
+            output.append({"Time": time.strftime("%H:%M:%S")})
         if args['python']:
             output.append(_get_pyversions())
         if args['packages']:

--- a/watermark/watermark.py
+++ b/watermark/watermark.py
@@ -172,10 +172,11 @@ def watermark(
                 value = iso_dt
             else:
                 values = []
-                if args['current_date']:
-                    values.append(time.strftime("%Y-%m-%d"))
-                elif args['datename']:
-                    values.append(time.strftime("%a %b %d %Y"))
+                if args['current_date'] or args['datename']:
+                    if args['datename']:
+                        values.append(time.strftime("%a %b %d %Y"))
+                    else:
+                        values.append(time.strftime("%Y-%m-%d"))
                 if args['current_time']:
                     time_str = time.strftime("%H:%M:%S")
                     if args['timezone']:
@@ -183,13 +184,14 @@ def watermark(
                     values.append(time_str)
                 value = " ".join(values)
             output.append({"Last updated": value})
-        if args['current_date'] and args['current_time']:
-            output.append({"Date": time.strftime("%Y-%m-%d")})
-            output.append({"Time": time.strftime("%H:%M:%S")})
-        elif args['current_date']:
-            output.append({"Date": time.strftime("%Y-%m-%d")})
-        elif args['current_time']:
-            output.append({"Time": time.strftime("%H:%M:%S")})
+        elif args['current_date'] or args['current_time']:
+            if args['current_date'] and args['current_time']:
+                output.append({"Date": time.strftime("%Y-%m-%d")})
+                output.append({"Time": time.strftime("%H:%M:%S")})
+            elif args['current_date']:
+                output.append({"Date": time.strftime("%Y-%m-%d")})
+            elif args['current_time']:
+                output.append({"Time": time.strftime("%H:%M:%S")})
         if args['python']:
             output.append(_get_pyversions())
         if args['packages']:


### PR DESCRIPTION
* added extra args outside of `args['updated']` to print `-d` (current date) and `-t` (current time) information without needing to use the `-u` (updated) flag

fixes #76