### PR TITLE
Feat cli implementation 60

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,13 @@ setup(
     packages=find_packages(exclude=[]),
     install_requires=install_reqs,
     extras_require={'gpu': ['py3nvml>=0.2']},
+    entry_points={
+        'console_scripts': [
+            'watermark=watermark.watermark:main', 
+        ],
+    },
     long_description=long_description,
     long_description_content_type="text/markdown",
 )
+
+

--- a/watermark/magic.py
+++ b/watermark/magic.py
@@ -27,7 +27,7 @@ class WaterMark(Magics):
     and various system information.
     """
     @magic_arguments()
-    @argument('-a', '--author', type=str,
+    @argument('-a', '--author', type=str, nargs='+',
               help='prints author name')
     @argument('-gu', '--github_username', type=str,
               help='prints author github username')
@@ -87,6 +87,12 @@ class WaterMark(Magics):
         """
         args = vars(parse_argstring(self.watermark, line))
 
+        if isinstance(args.get('author'), list):
+            args['author'] = " ".join(args['author'])
+
+        if isinstance(args.get('website'), list):
+            args['website'] = " ".join(args['website'])
+
         # renaming not to pollute the namespace
         # while preserving backward compatibility
         args['current_date'] = args.pop('date')
@@ -95,6 +101,8 @@ class WaterMark(Magics):
 
         formatted_text = watermark.watermark(**args)
         print(formatted_text)
+
+        
 
 
 def load_ipython_extension(ipython):

--- a/watermark/watermark.py
+++ b/watermark/watermark.py
@@ -472,3 +472,27 @@ def _get_latest_version(package_name):
             return data['info']['version']
     except Exception:
         return None
+
+def main():
+    import argparse
+    import sys
+    from watermark.watermark import watermark 
+    
+    parser = argparse.ArgumentParser(description='Watermark CLI')
+    parser.add_argument('-a', '--author', type=str, nargs='+', help='author name')
+    parser.add_argument('-v', '--python', action='store_true', help='python version')
+    parser.add_argument('-p', '--packages', type=str, help='comma-separated packages')
+
+    if len(sys.argv) == 1:
+        parser.print_help()
+        sys.exit(0)
+
+    args = vars(parser.parse_args())
+
+    if args.get('author'):
+        args['author'] = " ".join(args['author'])
+
+    print(watermark(**args))
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Hi @rasbt,

This PR introduces a Command Line Interface (CLI) for watermark, as discussed in issue #60. This enables the tool to be used in non-Python kernels (like R) or directly from the terminal via system("watermark") or shell commands.

Key Implementation Details:

Zero Dependencies: I chose to use the built-in argparse library instead of external tools like click. This keeps the package lightweight and avoids adding new dependencies, following your preference mentioned in the issue comments.

Entry Point: Added console_scripts to setup.py so that users can run watermark globally after installation.

Feature Parity: The CLI currently supports the most used flags:

-a / --author (Handles multi-word names with spaces/quotes).

-v / --python (Python version).

-p / --packages (Comma-separated package versions).

<img width="1274" height="522" alt="Screenshot (18)" src="https://github.com/user-attachments/assets/689e30aa-de57-440a-b3c9-a3460224e675" />

